### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,6 @@
 name: Vulnerability Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/javanhut/easyhttp/security/code-scanning/1](https://github.com/javanhut/easyhttp/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the workflow's operations. This change ensures that the workflow adheres to the principle of least privilege and mitigates potential security risks.

The `permissions` block should be added directly under the `name` key at the top of the file to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
